### PR TITLE
Fixes getId deprecation issue

### DIFF
--- a/src/main/kotlin/runconfig/RobotpyRunnerConfigurationFactory.kt
+++ b/src/main/kotlin/runconfig/RobotpyRunnerConfigurationFactory.kt
@@ -10,7 +10,7 @@ class RobotpyRunnerConfigurationFactory(type: ConfigurationType) : Configuration
         return RobotpyRunConfiguration(project, this, "Robotpy")
     }
 
-    override fun getId(): String = Type.TYPE_NAME
+    override fun getId(): String = FACTORY_NAME
 
     companion object {
         const val FACTORY_NAME = "Robotpy configuration factory"

--- a/src/main/kotlin/runconfig/RobotpyRunnerConfigurationFactory.kt
+++ b/src/main/kotlin/runconfig/RobotpyRunnerConfigurationFactory.kt
@@ -10,9 +10,7 @@ class RobotpyRunnerConfigurationFactory(type: ConfigurationType) : Configuration
         return RobotpyRunConfiguration(project, this, "Robotpy")
     }
 
-    override fun getName(): String {
-        return FACTORY_NAME
-    }
+    override fun getId(): String = Type.TYPE_NAME
 
     companion object {
         const val FACTORY_NAME = "Robotpy configuration factory"


### PR DESCRIPTION
Fixes issue from the following stacktrace:
```
com.intellij.diagnostic.PluginException: The default implementation of method 'getId' is deprecated, you need to override it in 'class runconfig.RobotpyRunnerConfigurationFactory'. The default implementation delegates to 'getName' which may be localized, but return value of this method must not depend on current localization. [Plugin: com.noskcaj19.robotpy-pycharm]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:83)
	at com.intellij.diagnostic.PluginException.reportDeprecatedDefault(PluginException.java:110)
	at com.intellij.execution.configurations.ConfigurationFactory.getId(ConfigurationFactory.java:75)
	at com.intellij.execution.impl.RunManagerImplKt.getFactoryKey(RunManagerImpl.kt:1398)
	at com.intellij.execution.impl.RunManagerImplKt.access$getFactoryKey(RunManagerImpl.kt:1)
	at com.intellij.execution.impl.RunManagerImpl.getConfigurationTemplate(RunManagerImpl.kt:341)
	at com.intellij.execution.impl.RunManagerImpl.createConfiguration(RunManagerImpl.kt:269)
	at toolwindow.RobotpyToolWindowPanel$1.mouseClicked(RobotpyToolWindow.kt:75)
	at java.desktop/java.awt.AWTEventMulticaster.mouseClicked(AWTEventMulticaster.java:278)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6657)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3345)
	at java.desktop/java.awt.Component.processEvent(Component.java:6419)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5029)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4861)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4556)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2793)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4861)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:778)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:751)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:749)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:748)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:898)
	at com.intellij.ide.IdeEventQueue.dispatchMouseEvent(IdeEventQueue.java:820)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:743)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:439)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:803)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:438)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:119)
	at com.intellij.ide.IdeEventQueue.performActivity(IdeEventQueue.java:604)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:436)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:873)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:484)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)

```